### PR TITLE
fix: Checkout latest main when triggered by workflow_call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # 全履歴取得（changelogに必要）
+          ref: ${{ github.event_name == 'workflow_call' && 'main' || '' }}  # workflow_callの場合は最新のmainを取得
 
       - name: Set version
         id: version
@@ -40,6 +41,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_call" ]; then
             # workflow_callトリガー: 呼び出し元から渡されたバージョンを使用
             VERSION="${{ inputs.version }}"
+            # タグは既にauto-version-bumpで作成済み
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # 手動トリガー: 入力されたバージョンを使用
             VERSION="${{ github.event.inputs.version }}"
@@ -62,13 +64,15 @@ jobs:
           echo "skip=false" >> $GITHUB_OUTPUT
           echo "📦 Releasing version: ${VERSION}"
 
-          # タグが存在しない場合は作成してpush
-          if ! git rev-parse "v${VERSION}" >/dev/null 2>&1; then
-            git tag -a "v${VERSION}" -m "Release v${VERSION}"
-            git push origin "v${VERSION}"
-            echo "✅ Created and pushed tag v${VERSION}"
-          else
-            echo "ℹ️  Tag v${VERSION} already exists locally"
+          # workflow_call以外の場合、タグを作成
+          if [ "${{ github.event_name }}" != "workflow_call" ]; then
+            if ! git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+              git tag -a "v${VERSION}" -m "Release v${VERSION}"
+              git push origin "v${VERSION}"
+              echo "✅ Created and pushed tag v${VERSION}"
+            else
+              echo "ℹ️  Tag v${VERSION} already exists locally"
+            fi
           fi
 
           # Ensure we're on the tagged commit


### PR DESCRIPTION
When release workflow is called via workflow_call from auto-version-bump, it needs to checkout the latest main branch (after VERSION update) instead of the default commit (before VERSION update).

Changes:
- Checkout: Use ref: main when event is workflow_call
- Set version: Skip tag creation when workflow_call (already done by auto-version-bump)
- Set version: Use inputs.version directly for workflow_call (no file read needed)